### PR TITLE
Support defining paths for .env files in composer.json

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,41 @@
+name: Linting
+
+on:
+  pull_request:
+
+jobs:
+  linters:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+          coverage: none
+          tools: composer
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install PHP dependencies
+        run: |
+          composer i
+          echo "::add-path::vendor/bin"
+
+      - name: Run linters
+        uses: wearerequired/lint-action@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          php_codesniffer: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Define `WP_ENVIRONMENT_TYPE` with the value of `WP_ENV` for WordPress 5.5 support.
 * Support Composer 2.0.
+* Delete `wp-config.php` after WordPress package is removed.
 
 ### Changed
 * Change default path for `.env` file to only search next to `wp-config.php`. Use `wp-config-env-paths` to change the path(s).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Define `WP_ENVIRONMENT_TYPE` with the value of `WP_ENV` for WordPress 5.5 support.
+* Support Composer 2.0.
 
 ### Changed
-* Update PHP dotenv dependency to v5.1.
-* Update env dependency to v2.1.
-* Only pass readable `.env` files to Dotenv to avoid a (suppressed) PHP warning by `Dotenv\Store\File\Reader::readFromFile()`.
+* Change default path for `.env` file to only search next to `wp-config.php`. Use `wp-config-env-paths` to change the path(s).
+* Update PHP dotenv dependency from v4.1 to v5.1.
+* Update env dependency from v1.1 to v2.1.
 
 ## [0.3.1] - 2020-05-12
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can override the path(s) with the following extra in your `composer.json`:
     "extra": {
         "wp-config-env-paths": [
             "../",
-            "../configs",
+            "../configs"
         ]
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Via Composer
 composer require johnpbloch/wordpress-core wearerequired/composer-wp-config
 ```
 
-Copy [`.env.example`](res/.env.example) and save it as `.env`. The variables are searched relative to `wp-config.php` in `../shared/.env`, `../configs/env`, `../.env`, or `./.env`.
+Copy [`.env.example`](res/.env.example) and save it as `.env`. By default the variables are searched in a `.env` file in the same directory as `wp-config.php` .
 
 ### List of required variables
 
@@ -32,6 +32,22 @@ Copy [`.env.example`](res/.env.example) and save it as `.env`. The variables are
 
 See also the list of [default constants](#default-constants).
 
+### Customize path to .env file
+You can override the path(s) with the following extra in your `composer.json`:
+
+```json
+{
+    "extra": {
+        "wp-config-env-paths": [
+            "../",
+            "../configs",
+        ]
+    }
+}
+```
+
+Note that the path must be relative to the `wp-config.php` file.
+
 ## Features
 
 * Creates `wp-config.php` one level above the WordPress installation.
@@ -44,7 +60,6 @@ See also the list of [default constants](#default-constants).
 
 ## Planned Features
 
-* Make path for `.env` file customizable via `composer.json`.
 * Allow to change required variables via `composer.json`.
 * Allow to change variables not used as a constant via `composer.json`.
 * Let us know what you think is missing…

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,13 @@
   },
   "require-dev": {
     "composer/composer": "1.6.* || 2.0.*@dev",
-    "composer/semver": "^1 || ^3"
+    "composer/semver": "^1 || ^3",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+    "wearerequired/coding-standards": "^1.5"
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0-dev"
+      "dev-master": "0.4.x-dev"
     },
     "class": "Required\\WpConfig\\Plugin"
   },
@@ -45,5 +47,9 @@
     "psr-4": {
       "Required\\WpConfig\\": "src"
     }
+  },
+  "scripts": {
+    "format": "vendor/bin/phpcbf --report-summary --report-source .",
+    "lint": "vendor/bin/phpcs --report-summary --report-source ."
   }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,15 +20,4 @@
 	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
 		<exclude-pattern>/src/Plugin\.php</exclude-pattern>
 	</rule>
-
-	<!-- Allow the use of filesystem functions. -->
-	<rule ref="WordPress.WP.AlternativeFunctions">
-		<properties>
-			<property name="exclude" type="array">
-				<element value="file_get_contents"/>
-				<element value="file_system_read"/>
-				<element value="file_put_contents"/>
-			</property>
-		</properties>
-	</rule>
 </ruleset>

--- a/res/wp-config.tpl.php
+++ b/res/wp-config.tpl.php
@@ -22,26 +22,18 @@ if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && 'https' === $_SERVER['HTTP_X
 /**
  * Require Composer's autoloader.
  */
-require_once __DIR__ . '/{{{VENDOR_DIR}}}/autoload.php';
+require_once __DIR__ . '/___WP_CONFIG_VENDOR_DIR___/autoload.php';
 
 global $table_prefix;
 
 /**
  * Environment variables.
  *
- * - Load from `../shared/.env`, `../configs/.env`, `../.env`, or `./.env`.
+ * - Load from `.env`.
  * - Check for required variables.
  * - Define constant for each variable if not already defined.
  */
-$root  = dirname( __DIR__ );
-$paths = [];
-foreach ( [ $root . '/shared', $root . '/configs', $root, __DIR__ ] as $path ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Gets unset afterwards.
-	if ( is_readable( $path . '/.env' ) ) {
-		$paths[] = $path;
-	}
-}
-
-$dotenv    = Dotenv::createUnsafeImmutable( $paths );
+$dotenv    = Dotenv::createUnsafeImmutable( ___WP_CONFIG_ENV_PATHS___ );
 $variables = $dotenv->load();
 $dotenv->required(
 	[

--- a/res/wp-config.tpl.php
+++ b/res/wp-config.tpl.php
@@ -83,7 +83,7 @@ array_walk(
 		}
 	}
 );
-unset( $root, $paths, $path, $dotenv, $variables, $variable_names );
+unset( $dotenv, $variables, $variable_names );
 
 /**
  * Environment settings.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -189,7 +189,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 				}
 			}
 		} else {
-			$env_paths_code[] = '__DI' . 'R__';
+			$env_paths_code[] = '__DI' . 'R__'; // phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found
 		}
 
 		$source = dirname( __DIR__ ) . '/res/wp-config.tpl.php';

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -164,7 +164,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$wordpressInstallDir = $installationManager->getInstallPath( $wordpressPackage );
 
 		if ( ! is_dir( $wordpressInstallDir ) ) {
-			$this->io->write( '<warning>The installation path of WordPress seems to be broken. wp-config.php not copied.</warning>' );
+			$this->io->writeError( '<warning>The installation path of WordPress seems to be broken. wp-config.php not copied.</warning>' );
 			return;
 		}
 
@@ -189,9 +189,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$copied = file_put_contents( $dest, $wpConfig );
 
 		if ( false !== $copied ) {
-			$this->io->write( '    wp-config.php has been copied to ' . $dest );
+			$this->io->writeError( '    wp-config.php has been copied to ' . $dest . '.' );
 		} else {
-			$this->io->write( '<error>wp-config.php could not be copied to ' . $dest . '</warning>' );
+			$this->io->writeError( '<error>wp-config.php could not be copied to ' . $dest . '.</error>' );
 		}
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -97,13 +97,13 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 */
 	public static function getSubscribedEvents() {
 		return [
-			PackageEvents::POST_PACKAGE_INSTALL => [
+			PackageEvents::POST_PACKAGE_INSTALL   => [
 				[ 'copyWpConfig' ],
 			],
-			PackageEvents::POST_PACKAGE_UPDATE  => [
+			PackageEvents::POST_PACKAGE_UPDATE    => [
 				[ 'copyWpConfig' ],
 			],
-			PackageEvents::POST_PACKAGE_UNINSTALL  => [
+			PackageEvents::POST_PACKAGE_UNINSTALL => [
 				[ 'deleteWpConfig' ],
 			],
 		];
@@ -172,20 +172,20 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$vendorDirRelative = self::getRelativePath( '/' . $wordpressInstallDir, '/' . $this->vendorDir );
 
 		$env_paths_code = [];
-		$extra = $this->composer->getPackage()->getExtra();
+		$extra          = $this->composer->getPackage()->getExtra();
 		if ( ! empty( $extra['wp-config-env-paths'] ) ) {
 			$env_paths = (array) $extra['wp-config-env-paths'];
 
-			foreach( $env_paths as $env_path ) {
+			foreach ( $env_paths as $env_path ) {
 				$env_path = ltrim( $env_path, '/' );
 				if ( $env_path ) {
 					$env_paths_code[] = sprintf(
-						// Don't use __DIR__ as it will cause a parse error in PluginManager.
-						'realpath( __DI' . 'R__ . \'%s\' )',
+						// Don't use __DIR__ as it will cause a parse error in Composer\Plugin\PluginManager.
+						'realpath( __DI' . 'R__ . \'%s\' )', // phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found
 						'/' . ltrim( $env_path, '/' )
 					);
 				} else {
-					$env_paths_code[] = '__DI' . 'R__';
+					$env_paths_code[] = '__DI' . 'R__'; // phpcs:ignore Generic.Strings.UnnecessaryStringConcat.Found
 				}
 			}
 		} else {
@@ -204,7 +204,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			],
 			[
 				$vendorDirRelative,
-				'[ ' . implode( ', ', $env_paths_code ) . ' ]'
+				'[ ' . implode( ', ', $env_paths_code ) . ' ]',
 			],
 			$wpConfig
 		);


### PR DESCRIPTION
Fixes https://github.com/wearerequired/composer-wp-config/issues/4.

The goal is to search only in the correct path instead of four "random" paths.