### PR TITLE
Load the WordPress plugin API early so hooks can be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Add support for automatically loading a file before (`wp-config-prepend.php`) and after (`wp-config-append.php`) the default config.
+* Load WordPress plugin API early so actions and filters can be used in `wp-config.php`, `wp-config-prepend.php`, and `wp-config-append.php`.
 
 ## [0.5.1] - 2021-06-11
 

--- a/res/wp-config.tpl.php
+++ b/res/wp-config.tpl.php
@@ -9,6 +9,11 @@ use Dotenv\Dotenv;
 use function Env\env;
 
 /**
+ * Load the WordPress plugin API early so hooks can be used.
+ */
+require_once ABSPATH . '/wp-includes/plugin.php';
+
+/**
  * Load a file that is automatically parsed before this config file.
  */
 if ( is_readable( __DIR__ . '/wp-config-prepend.php' ) ) {


### PR DESCRIPTION
This makes it possible to use `add_filter()` calls in `wp-config-prepend.php` or `wp-config-append`.

Related: https://core.trac.wordpress.org/ticket/34936, https://core.trac.wordpress.org/ticket/36819