### PR TITLE
Check if environment variables before creating

### DIFF
--- a/res/wp-config.tpl.php
+++ b/res/wp-config.tpl.php
@@ -47,10 +47,10 @@ global $table_prefix;
  * - Check for required variables.
  * - Define constant for each variable if not already defined.
  */
-$dotenv = Dotenv::createUnsafeImmutable( ___WP_CONFIG_ENV_PATHS___ );
+$dotenv    = Dotenv::createUnsafeImmutable( ___WP_CONFIG_ENV_PATHS___ );
 $variables = $dotenv->load();
 if ( empty( $variables ) ) {
-	$dotenv = Dotenv::createArrayBacked( ___WP_CONFIG_ENV_PATHS___ );
+	$dotenv    = Dotenv::createArrayBacked( ___WP_CONFIG_ENV_PATHS___ );
 	$variables = $dotenv->load();
 }
 $variables = $dotenv->load();


### PR DESCRIPTION
This is an issue when `WP_CLI::runcommand()` is used causing `wp-config.php` to be loaded a second time. Due to the environment variables already existing `Dotenv::createUnsafeImmutable()` returns an empty array causing the constants not to be set.