### PR TITLE
Add support for `WP_CONTENT_FOLDER_NAME` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* Add support for `WP_CONTENT_FOLDER_NAME` variable to customize the default value `content`.
+
+### Fixed
+* Avoid deprecation notice for use of deprecated `FILTER_SANITIZE_STRING` constant in PHP 8.1.
+
 ## [0.7.1] - 2022-12-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ If the following variables are not defined they will be assigned a default value
 | `WP_CACHE_KEY_SALT` | Value of `WP_ENV` |
 | `WP_HOME` | Based on `$_SERVER['SERVER_NAME']`/`_HTTP_HOST` and `$_SERVER['HTTPS']` |
 | `WP_SITEURL` |  Value of `WP_HOME` |
-| `WP_CONTENT_DIR` | `__DIR__ . '/content'` |
-| `WP_CONTENT_URL` | `WP_HOME . '/content'` |
+| `WP_CONTENT_FOLDER_NAME` | `'content'` |
+| `WP_CONTENT_DIR` | `__DIR__ . '/' . WP_CONTENT_FOLDER_NAME` |
+| `WP_CONTENT_URL` | `WP_HOME . '/' . WP_CONTENT_FOLDER_NAME` |
 
 ## Planned Features
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.7.x-dev"
+      "dev-master": "0.8.x-dev"
     },
     "class": "Required\\WpConfig\\Plugin"
   },

--- a/res/wp-config.tpl.php
+++ b/res/wp-config.tpl.php
@@ -81,6 +81,7 @@ array_walk(
 			case 'URL_DEVELOPMENT':
 			case 'URL_STAGING':
 			case 'URL_PRODUCTION':
+			case 'WP_CONTENT_FOLDER_NAME':
 				break;
 
 			// Assign table prefix to the $GLOBALS variable.
@@ -166,8 +167,12 @@ if ( ! defined( 'WP_HOME' ) ) {
 
 defined( 'WP_SITEURL' ) || define( 'WP_SITEURL', WP_HOME );
 
-defined( 'WP_CONTENT_DIR' ) || define( 'WP_CONTENT_DIR', __DIR__ . '/content' );
-defined( 'WP_CONTENT_URL' ) || define( 'WP_CONTENT_URL', WP_HOME . '/content' );
+if ( ! defined( 'WP_CONTENT_DIR' ) || ! defined( 'WP_CONTENT_URL' ) ) {
+	$wp_content_folder_name = env( 'WP_CONTENT_FOLDER_NAME' ) ?: 'content';
+	define( 'WP_CONTENT_DIR', __DIR__ . '/' . $wp_content_folder_name );
+	define( 'WP_CONTENT_URL', WP_HOME . '/' . $wp_content_folder_name );
+	unset( $wp_content_folder_name );
+}
 
 /**
  * Load a file that is automatically parsed after this config file


### PR DESCRIPTION
Before:

```
WP_HOME=${URL_DEVELOPMENT}
WP_CONTENT_DIR="{{DIR}}/wp-content"
WP_CONTENT_URL="${WP_HOME}/wp-content"
```

After:

```
WP_CONTENT_FOLDER_NAME="wp-content"
```


Fixes #39.